### PR TITLE
builds the node_id and relationship_id on cypher query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ end
 
 ## in some controller ##
 node = People.new(:name => 'Trinity', :title => 'computer programmer and hacker', :age => '27')
+node.save
 ```
 
 ### Nodes

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Keymaker.service.delete_relationship_request(:relationship_id => rel.neo4j_id)
 
 ### Models
 
-```
+```ruby
 class People
   include Keymaker::Node
     
@@ -137,6 +137,9 @@ class People
   index :people, :on => :age
 
 end
+
+## in some controller ##
+node = People.new(:name => 'Trinity', :title => 'computer programmer and hacker', :age => '27')
 ```
 
 ### Nodes
@@ -159,10 +162,11 @@ Coming soon
 
 ### Querying
 
-```
-## Cypher ##
+```ruby
+## Cypher #
 
-Coming soon
+results = Keymaker.service.execute_cypher("START n=node:tests(name='Trinity') return n", {})
+
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Coming soon
 
 ```
 ## Cypher ##
+
 Coming soon
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ Keymaker.service.delete_relationship_request(:relationship_id => rel.neo4j_id)
 
 ```
 
+### Models
+
+```
+class People
+  include Keymaker::Node
+    
+  property :name, String
+  property :age, Integer
+  property :title, String
+  
+  # creates an index called people with keys name and age
+  index :people, :on => :name
+  index :people, :on => :age
+
+end
+```
 ### Nodes
 
 ```

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Coming soon
 ### Querying
 
 ```
+## Cypher ##
 Coming soon
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ class People
 
 end
 ```
+
 ### Nodes
 
 ```

--- a/lib/keymaker.rb
+++ b/lib/keymaker.rb
@@ -45,18 +45,27 @@ module Keymaker
 
   VERSION = "0.1.0"
 
-  def self.service
-    @service ||= Keymaker::Service.new(Keymaker::Configuration.new)
-  end
+  class << self
+  
+    attr_accessor :logger
+    
+    def service
+      @service ||= Keymaker::Service.new(Keymaker::Configuration.new)
+    end
 
-  def self.configure
-    @configuration = Keymaker::Configuration.new
-    yield @configuration
-    @service = Keymaker::Service.new(@configuration)
+    def configure
+      @configuration = Keymaker::Configuration.new
+      yield @configuration
+      @service = Keymaker::Service.new(@configuration)
+    end
+  
+    def configuration
+      @configuration
+    end
+    
+    def logger
+      @logger ||= Logger.new(ENV['KEYMAKER_LOG'] ? ENV['KEYMAKER_LOG_FILE'] || $stdout : '/dev/null')
+    end
+    
   end
-
-  def self.configuration
-    @configuration
-  end
-
 end

--- a/lib/keymaker.rb
+++ b/lib/keymaker.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'faraday_middleware'
 require 'hashie'
+require 'logger'
 require 'active_model'
 require 'active_model/validations'
 require 'active_model/callbacks'

--- a/lib/keymaker/parsers/cypher_response_parser.rb
+++ b/lib/keymaker/parsers/cypher_response_parser.rb
@@ -4,11 +4,13 @@ module Keymaker
     def self.parse(response_body)
       response_body.data.map do |result|
         if response_body.columns.one? && result.first.kind_of?(Hashie::Mash)
-          result.first.data
+          thing_id = result.first.self.split('/').slice(-2,2)
+          result.first.data.merge({thing_id[0] + '_id' => thing_id[1].to_i})
         else
           translate_response(response_body, result)
         end
       end
+      
     end
 
     def self.translate_response(response_body, result)

--- a/lib/keymaker/railtie.rb
+++ b/lib/keymaker/railtie.rb
@@ -1,6 +1,9 @@
 require 'rails'
 
 class Railtie < Rails::Railtie
+  initializer 'Rails logger' do
+    Keymaker.logger = Rails.logger
+  end
   rake_tasks do
     load "keymaker/rails_tasks.rb"
   end

--- a/lib/keymaker/service.rb
+++ b/lib/keymaker/service.rb
@@ -81,6 +81,7 @@ module Keymaker
 
     def execute_cypher(query, params)
       response = execute_cypher_request({query: query, params: params})
+      Keymaker::logger.info(response.to_yaml)
       Keymaker::CypherResponseParser.parse(response.body)
     end
 

--- a/lib/keymaker/service.rb
+++ b/lib/keymaker/service.rb
@@ -80,8 +80,9 @@ module Keymaker
     end
 
     def execute_cypher(query, params)
+      Keymaker::logger.info("Keymaker:Cypher Request #{query.to_yaml}")
       response = execute_cypher_request({query: query, params: params})
-      Keymaker::logger.info(response.to_yaml)
+      Keymaker::logger.info("Keymaker:Cypher Response #{response.to_yaml}")
       Keymaker::CypherResponseParser.parse(response.body)
     end
 

--- a/spec/keymaker_spec.rb
+++ b/spec/keymaker_spec.rb
@@ -178,8 +178,25 @@ describe Keymaker do
       it "performs the cypher query and responds" do
         do_it.first.email.should == john_email
       end
-    end
 
+    end
+    
+    context "node results returned (array)" do
+      let(:cypher_string) { "START n=node(*) RETURN n" }
+      
+      it "returns the node id as node_id" do
+        do_it.first.node_id.should == john_node_id.to_i  
+      end
+    end
+    
+    context "relationship returned (array)" do
+      let(:cypher_string) { "START n=node(*) MATCH n-[r]-o RETURN r" }
+
+      it "returns the relationship id as relationship_id" do
+        relationship = Keymaker.service.create_relationship(:loves, john_node_id, sarah_node_id)
+        do_it.first.relationship_id.should == relationship.neo4j_id
+      end
+    end
   end
 
   context "nodes" do


### PR DESCRIPTION
On performing a cypher query, the results should contain the node_id or relationship_id in the results as the other non-cypher methods do. Without this there is no way to obtain the id in the results to perform further operations.

This pull req takes from the self parameter returned in the REST response and inserts the {node|relationship}_id into each of the results.
