### PR TITLE
Add cypher batch capability

### DIFF
--- a/keymaker.gemspec
+++ b/keymaker.gemspec
@@ -53,6 +53,7 @@ Gem::Specification.new do |s|
     lib/keymaker/railtie.rb
     lib/keymaker/request.rb
     lib/keymaker/requests/add_node_to_index_request.rb
+    lib/keymaker/requests/batch_cypher_request.rb
     lib/keymaker/requests/batch_get_nodes_request.rb
     lib/keymaker/requests/batch_request.rb
     lib/keymaker/requests/create_node_request.rb
@@ -73,6 +74,7 @@ Gem::Specification.new do |s|
     spec/configuration_spec.rb
     spec/keymaker/node_spec.rb
     spec/keymaker/requests/add_node_to_index_request_spec.rb
+    spec/keymaker/requests/batch_cypher_request_spec.rb
     spec/keymaker/requests/batch_get_nodes_request_spec.rb
     spec/keymaker/requests/batch_request_spec.rb
     spec/keymaker/requests/create_node_request_spec.rb

--- a/lib/keymaker.rb
+++ b/lib/keymaker.rb
@@ -20,6 +20,7 @@ require 'keymaker/service'
 require 'keymaker/request'
 
 require 'keymaker/requests/batch_request'
+require 'keymaker/requests/batch_cypher_request'
 require 'keymaker/requests/batch_get_nodes_request'
 require 'keymaker/requests/create_node_request'
 require 'keymaker/requests/delete_node_request'

--- a/lib/keymaker/parsers/cypher_response_parser.rb
+++ b/lib/keymaker/parsers/cypher_response_parser.rb
@@ -11,6 +11,12 @@ module Keymaker
       end
     end
 
+    def self.parse_array(response_array)
+      response_array.map{|response|
+        parse(response.body)
+      }
+    end
+
     def self.translate_response(response_body, result)
       Hashie::Mash.new(Hash[sanitized_column_names(response_body).zip(result)])
     end

--- a/lib/keymaker/requests/batch_cypher_request.rb
+++ b/lib/keymaker/requests/batch_cypher_request.rb
@@ -1,0 +1,35 @@
+module Keymaker
+
+  class BatchCypherRequest < BatchRequest
+
+    attr_accessor :queries
+
+    def initialize(service, queries)
+      self.config = service.config
+      self.queries = clean_queries(queries)
+      self.service = service
+      self.opts = build_job_descriptions_collection
+    end
+
+    def build_job_descriptions_collection
+      [].tap do |batch_jobs|
+        queries.each_with_index do |query, job_id|
+          batch_jobs << {id: job_id, to: '/cypher', method: "POST", body: query}
+        end
+      end
+    end
+
+    protected
+    def clean_queries(queries)
+      queries.map{ |query|
+        if query.is_a? String
+          { query: query}
+        else
+          query
+        end
+      }
+    end
+
+  end
+
+end

--- a/lib/keymaker/service.rb
+++ b/lib/keymaker/service.rb
@@ -84,6 +84,10 @@ module Keymaker
       Keymaker::CypherResponseParser.parse(response.body)
     end
 
+    def execute_cypher_batch(queries)
+      response = batch_cypher_request(queries)
+      Keymaker::CypherResponseParser.parse_array(response.body)
+    end
     def execute_script(script, params={})
       execute_gremlin_request({script: script, params: params})
     end

--- a/spec/keymaker/requests/batch_cypher_request_spec.rb
+++ b/spec/keymaker/requests/batch_cypher_request_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'keymaker'
+
+describe Keymaker::BatchCypherRequest do
+
+  describe "#build_opts_collection" do
+
+    context "with simple queries" do
+
+      let(:queries) { ['MATCH (n) RETURN COUNT(n)', 'MATCH (n) RETURN n LIMIT 1'] }
+      let(:batch_cypher_request) do
+        Keymaker::BatchCypherRequest.new(Keymaker.service, queries)
+      end
+
+      it "builds the job descriptions collection" do
+        batch_cypher_request.opts.should == [
+          {id: 0, to: "/cypher", method: "POST", body: { query: 'MATCH (n) RETURN COUNT(n)'}},
+          {id: 1, to: "/cypher", method: "POST", body: { query: 'MATCH (n) RETURN n LIMIT 1'}},
+        ]
+      end
+
+    end
+
+    context "with parametrized query" do
+
+      let(:queries) { [{query: 'MATCH (n { property: {property} }) RETURN n', :params => { property: 3 }}] }
+      let(:batch_cypher_request) do
+        Keymaker::BatchCypherRequest.new(Keymaker.service, queries)
+      end
+
+      it "builds the job descriptions collection" do
+        batch_cypher_request.opts.should == [
+          {id: 0, to: "/cypher", method: "POST", body: {query: 'MATCH (n { property: {property} }) RETURN n', :params => { property: 3 } }}
+        ]
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Add an execute_cypher_batch method in service that takes an array of cypher queries. 
A query can be a string or a hash for parameters ( exemple:  {query: 'MATCH (n { property: {property} }) RETURN n', :params => { property: 3 }} ).
