### PR TITLE
Make Faraday configurable from outside

### DIFF
--- a/lib/keymaker/configuration.rb
+++ b/lib/keymaker/configuration.rb
@@ -4,16 +4,17 @@ module Keymaker
   class Configuration
 
     attr_accessor :protocol, :server, :port, :data_directory,
-      :authentication, :username, :password
+      :authentication, :username, :password, :http_client_custom_initializer
 
     def initialize(attrs={})
-      self.protocol       = attrs.fetch(:protocol) {'http'}
-      self.server         = attrs.fetch(:server) {'localhost'}
-      self.port           = attrs.fetch(:port) {7474}
-      self.authentication = attrs.fetch(:authentication) {{}}
-      self.username       = attrs.fetch(:username) {nil}
-      self.password       = attrs.fetch(:password) {nil}
-      self.data_directory = 'db/data'
+      self.protocol                         = attrs.fetch(:protocol) {'http'}
+      self.server                           = attrs.fetch(:server) {'localhost'}
+      self.port                             = attrs.fetch(:port) {7474}
+      self.authentication                   = attrs.fetch(:authentication) {{}}
+      self.username                         = attrs.fetch(:username) {nil}
+      self.password                         = attrs.fetch(:password) {nil}
+      self.http_client_custom_initializer   = attrs.fetch(:http_client_custom_initializer) {->(http_client){}}
+      self.data_directory                   = 'db/data'
     end
 
     def service_root

--- a/lib/keymaker/service.rb
+++ b/lib/keymaker/service.rb
@@ -22,6 +22,7 @@ module Keymaker
         conn.response :mashify
         conn.response :json, :content_type => /\bjson$/
         conn.adapter :net_http
+        config.http_client_custom_initializer.call( conn )
       end
     end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -17,4 +17,20 @@ describe Keymaker::Service  do
     end
   end
 
+  context "with custom http client initializer provided" do
+    let(:options) { { http_client_custom_initializer: ->(conn){ conn.headers['X-Stream'] = 'true' }} }
+    let(:config) do
+      Keymaker::Configuration.new(options)
+    end
+
+    let(:service) { Keymaker::Service.new(config) }
+
+    describe "#connection" do
+      it "must be configured" do
+        service.connection.headers['X-Stream'].should == 'true'
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Add a http_client_custom_initializer attribute in configuration for initializing Faraday with a Proc.
This allows in particular to activate the Neo4j streaming mode by setting http header "X-Stream" to true.
